### PR TITLE
Adds make-config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "plugins": [
+    "node"
+  ],
+  "rules": {
+    "arrow-parens": ["error", "always"],
+    "no-var": "error",
+    "prefer-const": "error",
+    "array-bracket-spacing": ["error", "never"],
+    "comma-dangle": ["error", "never"],
+    "computed-property-spacing": ["error", "never"],
+    "eol-last": "error",
+    "eqeqeq": ["error", "smart"],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "no-confusing-arrow": ["error", { "allowParens": false }],
+    "no-extend-native": "error",
+    "no-mixed-spaces-and-tabs": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "no-unused-vars": "error",
+    "no-use-before-define": ["error", "nofunc"],
+    "object-curly-spacing": ["error", "always"],
+    "prefer-arrow-callback": "error",
+    "quotes": ["error", "single", "avoid-escape"],
+    "semi": ["error", "always"],
+    "space-infix-ops": "error",
+    "spaced-comment": ["error", "always"],
+    "keyword-spacing": ["error", { "before": true, "after": true }],
+    "template-curly-spacing": ["error", "never"],
+    "semi-spacing": "error",
+    "strict": "error",
+    "node/no-unsupported-features": ["error", { "version": 4 }],
+    "node/no-missing-require": "error"
+  }
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,10 +20,11 @@ const cli = meow({
   description: 'A CLI for bootstrapping GitHub labels'
 }, {
   alias: {
-    f: 'file',
+    o: 'owner',
+    r: 'repo',
     t: 'token'
   },
-  string: ['file', 'token']
+  string: ['owner', 'repo', 'token']
 });
 
 const command = cli.input[0];
@@ -31,11 +32,11 @@ const command = cli.input[0];
 let fn;
 try { fn = require(`../lib/${command}`); }
 catch (err) {
-  console.error(err.message);
+  console.error(`\n${err.message}\n`);
   cli.showHelp(1);
 }
 
 fn(cli.flags, (err, res) => {
-  if (err) console.log(err.message);
-  console.log(res);
+  if (err) console.log(`\n${err.message}\n`);
+  if (res) console.log(`\n${res}\n`);
 });

--- a/lib/make-config.js
+++ b/lib/make-config.js
@@ -5,23 +5,31 @@ const fs = require('fs');
 const inquirer = require('inquirer');
 
 module.exports = (options, callback) => {
-  fileDoesNotExist(filename, (err, res) => {
+  fileDoesNotExist(filename, (err) => {
     if (err) return callback(new Error(err));
     questionnaire((answers) => {
       const labels = makeJson(answers);
-      makeFile(labels, (err) => {
+      makeFile(filename, labels, (err) => {
         if (err) return callback(new Error(err));
         return callback(null, `Successfully created a ${filename} file!`);
       });
     });
   });
-}
+};
 
 module.exports.fileDoesNotExist = fileDoesNotExist;
 function fileDoesNotExist(filename, callback) {
-  fs.stat(`${__dirname}/../${filename}`, (err, res) => {
+  fs.stat(`${__dirname}/../${filename}`, (err) => {
     if (err) return callback();
-    return callback(`${filename} already exists in gh-bootstrap root directory.`);
+    inquirer.prompt([{
+      name: 'OverrideConfig',
+      type: 'confirm',
+      default: false,
+      message: `${filename} already exists in root directory. Would you like to proceed and override ${filename}?`
+    }]).then((answer) => {
+      if (!answer.OverrideConfig) return callback('Aborted!');
+      return callback();
+    });
   });
 }
 
@@ -34,7 +42,7 @@ function questionnaire(callback) {
     filter: Number
   }]).then((answers0) => {
     const questions = [];
-    for (var i = 1; i < answers0.NumberLabels + 1; i++) {
+    for (let i = 1; i < answers0.NumberLabels + 1; i++) {
       questions.push({
         name: `Label${i}Name`,
         type: 'input',
@@ -59,15 +67,15 @@ function questionnaire(callback) {
 module.exports.makeJson = makeJson;
 function makeJson(answers) {
   const json = { labels: {} };
-  for (var i = 1; i < answers.count + 1; i++) {
+  for (let i = 1; i < answers.count + 1; i++) {
     const key = answers[`Label${i}Name`];
     const value = (/^#.*$/.test(answers[`Label${i}Value`])) ? answers[`Label${i}Value`] : `#${answers[`Label${i}Value`]}`;
     json.labels[key] = value;
-  };
+  }
   return json;
 }
 
 module.exports.makeFile = makeFile;
-function makeFile(labels, callback) {
-  fs.writeFile(`${__dirname}/../config.json`, JSON.stringify(labels, null, 2), callback);
+function makeFile(filename, labels, callback) {
+  fs.writeFile(`${__dirname}/../${filename}`, JSON.stringify(labels, null, 2), callback);
 }

--- a/lib/make-config.js
+++ b/lib/make-config.js
@@ -4,8 +4,18 @@ const filename = 'config.json';
 const fs = require('fs');
 const inquirer = require('inquirer');
 
-module.exports = (options, callback) => {
-  fileDoesNotExist(filename, (err) => {
+/**
+ * A function to create a configuration file. If the configuration file already
+ * exists, prompt the user to confirm they would like to override it. Then gather
+ * information from the user about desired label names and associated hex values.
+ * Finally, write the label information to the configuration file.
+ *
+ * @function run
+ * @param {object} options - placeholder for CLI flags
+ */
+module.exports = run;
+function run(options, callback) {
+  confirmFileCreation(filename, (err) => {
     if (err) return callback(new Error(err));
     questionnaire((answers) => {
       const labels = makeJson(answers);
@@ -17,8 +27,15 @@ module.exports = (options, callback) => {
   });
 };
 
-module.exports.fileDoesNotExist = fileDoesNotExist;
-function fileDoesNotExist(filename, callback) {
+/**
+ * A function to check if configuration file already exists. If so, prompt the user
+ * to confirm that they would like to override it.
+ *
+ * @function confirmFileCreation
+ * @param {string} filename
+ */
+module.exports.confirmFileCreation = confirmFileCreation;
+function confirmFileCreation(filename, callback) {
   fs.stat(`${__dirname}/../${filename}`, (err) => {
     if (err) return callback();
     inquirer.prompt([{
@@ -33,6 +50,12 @@ function fileDoesNotExist(filename, callback) {
   });
 }
 
+/**
+ * A function to ask the user how many labels they would like to create, gathering
+ * label names and hex values for each.
+ *
+ * @function questionnaire
+ */
 module.exports.questionnaire = questionnaire;
 function questionnaire(callback) {
   inquirer.prompt([{
@@ -64,6 +87,13 @@ function questionnaire(callback) {
   });
 }
 
+/**
+ * A function to create a JSON object from the questionnaire answers, where the
+ * keys are the label names, and the values are the label hex values.
+ *
+ * @function makeJson
+ * @param {object} answers - answers object returned by the `questionnaire`function
+ */
 module.exports.makeJson = makeJson;
 function makeJson(answers) {
   const json = { labels: {} };
@@ -75,6 +105,15 @@ function makeJson(answers) {
   return json;
 }
 
+
+/**
+ * A function to write the object returned by the `makeJson` function to the configuration
+ * file.
+ *
+ * @function makeFile
+ * @param {string} filename
+ * @param {object} labels - labels object returned by `makeJson` function
+ */
 module.exports.makeFile = makeFile;
 function makeFile(filename, labels, callback) {
   fs.writeFile(`${__dirname}/../${filename}`, JSON.stringify(labels, null, 2), callback);

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   "homepage": "https://github.com/emilymdubois/gh-bootstrap#readme",
   "devDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-node": "^4.2.2"
+    "eslint-plugin-node": "^4.2.2",
+    "sinon": "^2.2.0",
+    "tape": "^4.6.3"
   },
   "dependencies": {
-    "async": "^2.3.0",
     "d3-queue": "^3.0.5",
     "inquirer": "^3.0.6",
     "meow": "^3.7.0",

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,25 @@
+# gh-bootstrap
+
+Utility scripts to bootstrap GitHub repositories the way you like them.
+
+## Install
+
+```sh
+$ git clone git@github.com:emilymdubois/gh-bootstrap.git
+$ cd gh-bootstrap
+$ npm link
+```
+
+## Set up configuration file
+
+```sh
+$ gh-bootstrap make-config
+```
+
+This will create a `config.json` file in the root directory of your local gh-bootstrap clone.
+
+## Test
+
+```sh
+$ npm test
+```

--- a/test/make-config.test.js
+++ b/test/make-config.test.js
@@ -23,23 +23,23 @@ const labels = {
   }
 };
 
-test('[make-config] [fileDoesNotExist]', (t) => {
+test('[make-config] [confirmFileCreation]', (t) => {
   const stat = sinon.stub(fs, 'stat');
   const prompt = sinon.stub(inquirer, 'prompt');
 
-  t.test('[make-config] [fileDoesNotExist] fs.stat error', (assert) => {
+  t.test('[make-config] [confirmFileCreation] fs.stat error', (assert) => {
     stat.onCall(0).yields(error);
-    file.fileDoesNotExist(filename, (err, res) => {
+    file.confirmFileCreation(filename, (err, res) => {
       assert.ok(/^.*config-test.json$/.test(stat.getCall(0).args[0]), 'fs.stat argument should contain filename');
       assert.ifError(err || res, 'should not accept callback parameters');
       assert.end();
     });
   });
 
-  t.test('[make-config] [fileDoesNotExist] inquirer.prompt no confirmation', (assert) => {
+  t.test('[make-config] [confirmFileCreation] inquirer.prompt no confirmation', (assert) => {
     stat.onCall(1).yields(null, success);
     prompt.onCall(0).returns(Promise.resolve({ OverrideConfig: false }));
-    file.fileDoesNotExist(filename, (err, res) => {
+    file.confirmFileCreation(filename, (err, res) => {
       assert.ok(/^.*config-test.json$/.test(stat.getCall(1).args[0]), 'fs.stat argument should contain filename');
       assert.deepEqual(prompt.getCall(0).args[0], [{
         default: false,
@@ -53,10 +53,10 @@ test('[make-config] [fileDoesNotExist]', (t) => {
     });
   });
 
-  t.test('[make-config] [fileDoesNotExist] inquirer.prompt confirmation', (assert) => {
+  t.test('[make-config] [confirmFileCreation] inquirer.prompt confirmation', (assert) => {
     stat.onCall(2).yields(null, success);
     prompt.onCall(1).returns(Promise.resolve({ OverrideConfig: true }));
-    file.fileDoesNotExist(filename, (err, res) => {
+    file.confirmFileCreation(filename, (err, res) => {
       assert.ok(/^.*config-test.json$/.test(stat.getCall(1).args[0]), 'fs.stat argument should contain filename');
       assert.deepEqual(prompt.getCall(0).args[0], [{
         default: false,
@@ -69,7 +69,7 @@ test('[make-config] [fileDoesNotExist]', (t) => {
     });
   });
 
-  t.test('[make-config] [fileDoesNotExist] restore', (assert) => {
+  t.test('[make-config] [confirmFileCreation] restore', (assert) => {
     fs.stat.restore();
     inquirer.prompt.restore();
     assert.end();

--- a/test/make-config.test.js
+++ b/test/make-config.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const file = require(`${__dirname}/../lib/make-config`);
+const fs = require('fs');
+const inquirer = require('inquirer');
+const sinon = require('sinon');
+const test = require('tape');
+
+const error = 'some error';
+const success = 'some success message';
+const filename = 'config-test.json';
+const answers = {
+  Label1Name: 'bug',
+  Label1Value: '#fff',
+  Label2Name: 'feature',
+  Label2Value: '#000',
+  count: 2
+};
+const labels = {
+  labels: {
+    bug: '#fff',
+    feature: '#000'
+  }
+};
+
+test('[make-config] [fileDoesNotExist]', (t) => {
+  const stat = sinon.stub(fs, 'stat');
+  const prompt = sinon.stub(inquirer, 'prompt');
+
+  t.test('[make-config] [fileDoesNotExist] fs.stat error', (assert) => {
+    stat.onCall(0).yields(error);
+    file.fileDoesNotExist(filename, (err, res) => {
+      assert.ok(/^.*config-test.json$/.test(stat.getCall(0).args[0]), 'fs.stat argument should contain filename');
+      assert.ifError(err || res, 'should not accept callback parameters');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [fileDoesNotExist] inquirer.prompt no confirmation', (assert) => {
+    stat.onCall(1).yields(null, success);
+    prompt.onCall(0).returns(Promise.resolve({ OverrideConfig: false }));
+    file.fileDoesNotExist(filename, (err, res) => {
+      assert.ok(/^.*config-test.json$/.test(stat.getCall(1).args[0]), 'fs.stat argument should contain filename');
+      assert.deepEqual(prompt.getCall(0).args[0], [{
+        default: false,
+        message: `${filename} already exists in root directory. Would you like to proceed and override ${filename}?`,
+        name: 'OverrideConfig',
+        type: 'confirm'
+      }], 'inquirer.prompt argument should contain expected parameters');
+      assert.equal(err, 'Aborted!', 'should abort if user does not confirm file override');
+      assert.ifError(res, 'should not accept callback success parameter');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [fileDoesNotExist] inquirer.prompt confirmation', (assert) => {
+    stat.onCall(2).yields(null, success);
+    prompt.onCall(1).returns(Promise.resolve({ OverrideConfig: true }));
+    file.fileDoesNotExist(filename, (err, res) => {
+      assert.ok(/^.*config-test.json$/.test(stat.getCall(1).args[0]), 'fs.stat argument should contain filename');
+      assert.deepEqual(prompt.getCall(0).args[0], [{
+        default: false,
+        message: `${filename} already exists in root directory. Would you like to proceed and override ${filename}?`,
+        name: 'OverrideConfig',
+        type: 'confirm'
+      }], 'inquirer.prompt argument should contain expected parameters');
+      assert.ifError(err || res, 'should not accept callback parameters');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [fileDoesNotExist] restore', (assert) => {
+    fs.stat.restore();
+    inquirer.prompt.restore();
+    assert.end();
+  });
+
+  t.end();
+});
+
+test('[make-config] [questionnaire]', (t) => {
+  const prompt = sinon.stub(inquirer, 'prompt');
+
+  t.test('[make-config] [questionnaire] 2 labels', (assert) => {
+    prompt.onCall(0).returns(Promise.resolve({ NumberLabels: 2 }));
+    prompt.onCall(1).returns(Promise.resolve({ Label1Name: 'bug', Label1Value: '#fff', Label2Name: 'feature', Label2Value: '#000' }));
+    file.questionnaire((res) => {
+      /* Stringify validate functions */
+      const stringified = prompt.getCall(1).args[0].map((q) => {
+        if (q.validate) q.validate = q.validate.toString();
+        return q;
+      });
+
+      assert.deepEqual(prompt.getCall(0).args[0], [{
+        filter: Number,
+        message: 'How many labels would you like to configure?',
+        name: 'NumberLabels',
+        type: 'input'
+      }], 'inquirer.prompt argument should contain expected parameters');
+      assert.deepEqual(stringified, [
+        { message: 'Label 1 name:', name: 'Label1Name', type: 'input' },
+        { message: 'Label 1 hex value:', name: 'Label1Value', type: 'input', validate: '(input) => {\n          return /^#?[a-fA-F0-9]{3,6}$/.test(input);\n        }' },
+        { message: 'Label 2 name:', name: 'Label2Name', type: 'input' },
+        { message: 'Label 2 hex value:', name: 'Label2Value', type: 'input', validate: '(input) => {\n          return /^#?[a-fA-F0-9]{3,6}$/.test(input);\n        }' }
+      ], 'inquirer.prompt argument should contain expected parameters');
+      assert.deepEqual(res, answers, 'should return expected response');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [questionnaire] restore', (assert) => {
+    inquirer.prompt.restore();
+    assert.end();
+  });
+
+  t.end();
+});
+
+test('[make-config] [makeJson]', (t) => {
+  const result = file.makeJson(answers);
+  t.deepEqual(result, labels, 'should return expected JSON object');
+  t.end();
+});
+
+test('[make-config] [makeFile]', (t) => {
+  const writeFile = sinon.stub(fs, 'writeFile');
+
+  t.test('[make-config] [makeFile] error', (assert) => {
+    writeFile.onCall(0).yields(error);
+    file.makeFile(filename, labels, (err, res) => {
+      assert.ok(/^.*config-test.json$/.test(writeFile.getCall(0).args[0]), 'fs.stat arguments should contain filename');
+      assert.deepEqual(writeFile.getCall(0).args[1], JSON.stringify(labels, null, 2), 'fs.stat arguments should contain stringified labels object');
+      assert.equal(err, error, 'callback should pass through fs.writeFile error');
+      assert.ifError(res, 'should not accept callback success parameter');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [makeFile] success', (assert) => {
+    writeFile.onCall(1).yields(null, success);
+    file.makeFile(filename, labels, (err, res) => {
+      assert.ok(/^.*config-test.json$/.test(writeFile.getCall(1).args[0]), 'fs.stat arguments should contain filename');
+      assert.deepEqual(writeFile.getCall(1).args[1], JSON.stringify(labels, null, 2), 'fs.stat arguments should contain stringified labels object');
+      assert.ifError(err, 'should not error');
+      assert.equal(res, success, 'should return success message');
+      assert.end();
+    });
+  });
+
+  t.test('[make-config] [makefile] restore', (assert) => {
+    fs.writeFile.restore();
+    assert.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
This PR adds `make-config`, a CLI command for creating a local configuration file. Currently, this configuration file is populated with label names and hex values.

To do:
- [x] Add in-line documentation